### PR TITLE
 fix #115, add ai-prompt-auto-commit hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "id": "ai-prompt-auto-commit",
+            "type": "command",
+            "command": "input=$(cat); ts=$(date +%Y-%m-%dT%H-%M-%S); model=$(printf '%s' \"$input\" | jq -r '.model // \"claude-sonnet-4-6\"'); printf '%s' \"$input\" | jq -r '.prompt' > \".prompts/${ts}_${model}.md\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pycalendar/ai-prompt-auto-commit
+    rev: v0.0.5
+    hooks:
+      - id: unstage-ai-prompts
+      - id: append-ai-prompts
+        stages: [prepare-commit-msg]
+      - id: archive-ai-prompts
+        stages: [post-commit]
+      - id: prepare-ai-repository
+        stages: [manual]

--- a/calendar_cli/metadata.py
+++ b/calendar_cli/metadata.py
@@ -3,7 +3,7 @@ metadata = {
     "author": "Tobias Brox",
     "author_short": "tobixen",
     "copyright": "Copyright 2013-2022, Tobias Brox and contributors",
-    "license": "GPLv3+",
+    "license": "GPL-3.0-or-later",
     "license_url": "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
     "maintainer": "Tobias Brox",
     "author_email": "t-calendar-cli@tobixen.no",


### PR DESCRIPTION
Fix https://github.com/tobixen/calendar-cli/issues/115: change license string in calendar_cli/metadata.py from "GPLv3+" to the valid SPDX identifier "GPL-3.0-or-later".

Add .pre-commit-config.yaml with ai-prompt-auto-commit hooks (v0.0.5) ref https://github.com/pycalendar/ai-prompt-auto-commit The hooks record Claude Code prompts into .prompts/ and inject them into commit messages automatically.

Also installs the Claude Code UserPromptSubmit hook into .claude/settings.json via `pre-commit run --hook-stage manual prepare-ai-repository`.

prompt: Fix the ai prompt precommit as described in ~/.claude/skills/python-project-modernization.md - then deal with issue #115. commit both work tasks to the same feature/bugfixing branch and create a pull request